### PR TITLE
gets to Edits on devDebug when tapping the edit tab

### DIFF
--- a/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
+++ b/app/src/main/java/org/wikipedia/suggestededits/SuggestedEditsTasksFragment.kt
@@ -17,6 +17,7 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.wikipedia.BuildConfig.BUILD_TYPE
 import org.wikipedia.Constants
 import org.wikipedia.R
 import org.wikipedia.WikipediaApp
@@ -220,7 +221,7 @@ class SuggestedEditsTasksFragment : Fragment() {
                         isPausedOrDisabled = true
                     }
 
-                    if (!isPausedOrDisabled && blockMessage.isNullOrEmpty()) {
+                    if (!isPausedOrDisabled && blockMessage.isNullOrEmpty()|| BUILD_TYPE=="debug") {
                         binding.pageViewStatsView.setTitle(it.toString())
                         totalPageviews = it
                         setFinalUIState()


### PR DESCRIPTION
https://trello.com/c/0q36vCjQ/6-hide-easy-edit-call-to-action-buttons-and-instead-roll-them-into-the-edit-button
Dealing with Debug flag to allow editing articles